### PR TITLE
Fixed issues with environment variables

### DIFF
--- a/ismdust.f90
+++ b/ismdust.f90
@@ -69,14 +69,13 @@ integer inunit,readwrite,blocksize
 integer :: hdutype,colnum
 integer :: felem=1, nulld=0
 logical :: anynull
-character (len=255) :: fgmstr
-external :: fgmstr
 !Number of elements for each grain type cross section.
 nemax=25530
 ! Where do we look for the data?
-ismdust_root = trim(fgmstr('ISMDUSTROOT'))
+call getenv('ISMDUSTROOT', ismdust_root)
 if (ismdust_root .EQ. '') then
 ismdust_root = local_dir
+print *, 'cannot find any ISMDUSTROOT environment'
 endif
 ! parameters to specify the opening process
 status=0

--- a/ismdust.f90
+++ b/ismdust.f90
@@ -59,10 +59,10 @@ integer,parameter :: ngrain=1, out_unit=20
 integer :: bnene, ifl, i, j, status
 integer :: nemax
 double precision :: ener(bnene), xs(0:ngrain,bnene)
-character (*), parameter :: fileloc = 'xs_ext_grid.fits'
+character (*), parameter :: fileloc = '/edge_files/xs_ext_grid.fits'
 character (*), parameter :: ismreadchat = 'ismdust: reading from '
 character (len=255 + 29) :: filename2 ! len(fileloc)
-character (len=240) :: local_dir = './edge_files/'
+character (len=240) :: local_dir = '.'
 character (len=255) :: ismdust_root = ''
 character (len=len(ismreadchat)+len(filename2)) :: chatmsg = ''
 integer inunit,readwrite,blocksize


### PR DESCRIPTION
I changed from fgmstr to getenv command in f90 file. This fixed recent issues around correctly grabbing the cross-section files.